### PR TITLE
Add cross-platform build support for Windows-only tools

### DIFF
--- a/fs-patch-process/Cargo.toml
+++ b/fs-patch-process/Cargo.toml
@@ -7,4 +7,6 @@ edition = "2024"
 anyhow = "1.0.99"
 argh = "0.1.13"
 fs-lib = { version = "1.0.0", path = "../fs-lib" }
+
+[target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["handleapi", "memoryapi", "processthreadsapi", "psapi", "tlhelp32"] }

--- a/fs-patch-process/src/main.rs
+++ b/fs-patch-process/src/main.rs
@@ -1,111 +1,126 @@
-use std::{path::PathBuf, process::Command};
-
-use anyhow::{Result, bail};
-use argh::FromArgs;
-use fs_lib::{EXECUTABLE_PATTERNS, Platform, buffer::BufferExtension};
-
-use crate::process::{get_process_modules, open_process, resume_process, suspend_process};
-
+#[cfg(windows)]
 mod process;
 
-#[derive(FromArgs, PartialEq, Debug)]
-/// Launch executable as child process and patch memory
-pub struct Cmd {
-    /// path to executable
-    #[argh(positional)]
-    input: PathBuf,
+#[cfg(windows)]
+mod windows {
+    use std::{path::PathBuf, process::Command};
 
-    /// platform: steam, giants (default: steam)
-    #[argh(option, default = "Platform::Steam")]
-    platform: Platform,
+    use anyhow::{Result, bail};
+    use argh::FromArgs;
+    use fs_lib::{EXECUTABLE_PATTERNS, Platform, buffer::BufferExtension};
 
-    /// use PID of already running process instead
-    #[argh(option)]
-    pid: Option<u32>,
+    use crate::process::{get_process_modules, open_process, resume_process, suspend_process};
 
-    /// stop process instead of resuming
-    #[argh(switch)]
-    test: bool,
+    #[derive(FromArgs, PartialEq, Debug)]
+    /// Launch executable as child process and patch memory
+    pub struct Cmd {
+        /// path to executable
+        #[argh(positional)]
+        input: PathBuf,
 
-    /// don't wait for child process to exit
-    #[argh(switch)]
-    no_wait: bool,
+        /// platform: steam, giants (default: steam)
+        #[argh(option, default = "Platform::Steam")]
+        platform: Platform,
+
+        /// use PID of already running process instead
+        #[argh(option)]
+        pid: Option<u32>,
+
+        /// stop process instead of resuming
+        #[argh(switch)]
+        test: bool,
+
+        /// don't wait for child process to exit
+        #[argh(switch)]
+        no_wait: bool,
+    }
+
+    pub fn run() -> Result<()> {
+        let cli: Cmd = argh::from_env();
+
+        let Some(items) = EXECUTABLE_PATTERNS.get(&cli.platform) else {
+            bail!("No patch items found")
+        };
+
+        let (pid, child_process) = match cli.pid {
+            Some(id) => (id, None),
+            _ => {
+                let child_process = Command::new(&cli.input).spawn()?;
+
+                println!("Started new child ProcessID: {}", child_process.id());
+
+                (child_process.id(), Some(child_process))
+            }
+        };
+
+        if !suspend_process(pid) {
+            bail!("Failed to suspend child process")
+        }
+
+        println!("Suspended process");
+
+        let process_handle = open_process(pid)?;
+        let modules = get_process_modules(&process_handle, pid)?;
+
+        println!("Found {} process modules", modules.len());
+
+        let file_name = cli
+            .input
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+
+        let Some(module) = modules.iter().find(|m| m.name == file_name) else {
+            bail!("Unable to locate main process module")
+        };
+
+        println!("Module name: {}", module.name);
+        println!("Module base_addr: {}", module.base_addr);
+        println!("Module base_size: {}", module.base_size);
+
+        let (module_buffer, bytes_read) = module.to_buffer(&process_handle)?;
+
+        println!("{} bytes read from module memory into buffer", bytes_read);
+
+        for item in items {
+            if let Some(offset) = module_buffer.find_bytes(&item.find) {
+                println!("Applying {:?} at offset {}", item.patch_type, offset);
+
+                let bytes_written = module.replace_bytes(&item.replace, offset, &process_handle)?;
+
+                println!("Bytes written: {}", bytes_written)
+            }
+        }
+
+        println!("Resuming process");
+
+        if !resume_process(pid) {
+            bail!("Failed to resume process!")
+        }
+
+        if let Some(mut child_process) = child_process {
+            if cli.test {
+                println!("Klling child process");
+                let _ = child_process.kill();
+            } else if !cli.no_wait {
+                println!("Waiting for child process to exit");
+
+                let _ = child_process.wait();
+            }
+        }
+
+        Ok(())
+    }
 }
 
-fn main() -> Result<()> {
-    let cli: Cmd = argh::from_env();
+#[cfg(windows)]
+fn main() -> anyhow::Result<()> {
+    windows::run()
+}
 
-    let Some(items) = EXECUTABLE_PATTERNS.get(&cli.platform) else {
-        bail!("No patch items found")
-    };
-
-    let (pid, child_process) = match cli.pid {
-        Some(id) => (id, None),
-        _ => {
-            let child_process = Command::new(&cli.input).spawn()?;
-
-            println!("Started new child ProcessID: {}", child_process.id());
-
-            (child_process.id(), Some(child_process))
-        }
-    };
-
-    if !suspend_process(pid) {
-        bail!("Failed to suspend child process")
-    }
-
-    println!("Suspended process");
-
-    let process_handle = open_process(pid)?;
-    let modules = get_process_modules(&process_handle, pid)?;
-
-    println!("Found {} process modules", modules.len());
-
-    let file_name = cli
-        .input
-        .file_name()
-        .unwrap()
-        .to_string_lossy()
-        .into_owned();
-
-    let Some(module) = modules.iter().find(|m| m.name == file_name) else {
-        bail!("Unable to locate main process module")
-    };
-
-    println!("Module name: {}", module.name);
-    println!("Module base_addr: {}", module.base_addr);
-    println!("Module base_size: {}", module.base_size);
-
-    let (module_buffer, bytes_read) = module.to_buffer(&process_handle)?;
-
-    println!("{} bytes read from module memory into buffer", bytes_read);
-
-    for item in items {
-        if let Some(offset) = module_buffer.find_bytes(&item.find) {
-            println!("Applying {:?} at offset {}", item.patch_type, offset);
-
-            let bytes_written = module.replace_bytes(&item.replace, offset, &process_handle)?;
-
-            println!("Bytes written: {}", bytes_written)
-        }
-    }
-
-    println!("Resuming process");
-
-    if !resume_process(pid) {
-        bail!("Failed to resume process!")
-    }
-
-    if let Some(mut child_process) = child_process {
-        if cli.test {
-            println!("Klling child process");
-            let _ = child_process.kill();
-        } else if !cli.no_wait {
-            println!("Waiting for child process to exit");
-
-            let _ = child_process.wait();
-        }
-    }
-
-    Ok(())
+#[cfg(not(windows))]
+fn main() {
+    eprintln!("fs-patch-process is only supported on Windows");
+    std::process::exit(1);
 }

--- a/fs-unpack/Cargo.toml
+++ b/fs-unpack/Cargo.toml
@@ -6,5 +6,7 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0.99"
 argh = "0.1.13"
-winapi = { version = "0.3", features = ["libloaderapi"] }
 fs-lib = { version = "1.0.0", path = "../fs-lib" }
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["libloaderapi"] }

--- a/fs-unpack/src/main.rs
+++ b/fs-unpack/src/main.rs
@@ -1,154 +1,168 @@
-use std::{
-    ffi::{CString, c_uint, c_void},
-    fs::File,
-    mem::transmute,
-    path::PathBuf,
-};
+#[cfg(windows)]
+mod windows {
+    use std::{
+        ffi::{CString, c_uint, c_void},
+        fs::File,
+        mem::transmute,
+        path::PathBuf,
+    };
 
-use winapi::um::libloaderapi::{GetProcAddress, LoadLibraryA};
+    use winapi::um::libloaderapi::{GetProcAddress, LoadLibraryA};
 
-use anyhow::{Result, bail, ensure};
-use argh::FromArgs;
-use fs_lib::{KEYS_LIST, buffer::BufferExtension, byte_array_hex_string, file::FileExtension};
+    use anyhow::{Result, bail, ensure};
+    use argh::FromArgs;
+    use fs_lib::{KEYS_LIST, buffer::BufferExtension, byte_array_hex_string, file::FileExtension};
 
-#[derive(FromArgs, PartialEq, Debug)]
-/// Extract .gar/.pdlc archive
-pub struct Cmd {
-    /// path to .gar/.pdlc archive
-    #[argh(positional)]
-    input: PathBuf,
+    #[derive(FromArgs, PartialEq, Debug)]
+    /// Extract .gar/.pdlc archive
+    pub struct Cmd {
+        /// path to .gar/.pdlc archive
+        #[argh(positional)]
+        input: PathBuf,
 
-    /// output path
-    #[argh(positional)]
-    output_path: PathBuf,
-}
-
-type DefarmFn = unsafe extern "C" fn(
-    input: *const c_void,
-    input_size: c_uint,
-    output: *mut c_void,
-    key1: c_uint,
-    key2: c_uint,
-    key3: c_uint,
-    key4: c_uint,
-);
-
-type DecryptFn = dyn Fn(&Vec<u8>, &[u32; 4]) -> Result<Vec<u8>>;
-
-fn find_keys(file: &mut File, decrypt_fn: &DecryptFn) -> Result<[u32; 4]> {
-    let test_bytes = file.read_bytes(512, 8)?;
-
-    for keys in KEYS_LIST.iter() {
-        let result = decrypt_fn(&test_bytes, &keys)?;
-
-        if result.read_u32(0) == 1 {
-            return Ok(keys.clone());
-        }
+        /// output path
+        #[argh(positional)]
+        output_path: PathBuf,
     }
 
-    bail!("Failed to find valid decryption key")
-}
+    type DefarmFn = unsafe extern "C" fn(
+        input: *const c_void,
+        input_size: c_uint,
+        output: *mut c_void,
+        key1: c_uint,
+        key2: c_uint,
+        key3: c_uint,
+        key4: c_uint,
+    );
 
-fn load_decrypt_function() -> Result<impl Fn(&Vec<u8>, &[u32; 4]) -> Result<Vec<u8>>> {
-    // Load the 32-bit DLL
-    let dll_path = CString::new("defarm.dll").unwrap();
-    let h_module = unsafe { LoadLibraryA(dll_path.as_ptr()) };
-    if h_module == std::ptr::null_mut() {
-        panic!("Failed to load 'defarm.dll'");
-    }
+    type DecryptFn = dyn Fn(&Vec<u8>, &[u32; 4]) -> Result<Vec<u8>>;
 
-    // Get the function address
-    let func_name = CString::new("defarm").unwrap();
-    let func_ptr = unsafe { GetProcAddress(h_module, func_name.as_ptr()) };
-    if func_ptr.is_null() {
-        panic!("Failed to find function entry pointer to 'defarm' in 'defarm.dll'");
-    }
+    fn find_keys(file: &mut File, decrypt_fn: &DecryptFn) -> Result<[u32; 4]> {
+        let test_bytes = file.read_bytes(512, 8)?;
 
-    let function: DefarmFn = unsafe { transmute(func_ptr) };
+        for keys in KEYS_LIST.iter() {
+            let result = decrypt_fn(&test_bytes, &keys)?;
 
-    Ok(move |input: &Vec<u8>, keys: &[u32; 4]| {
-        let length = input.len();
-        let mut output: Vec<u8> = vec![0; length];
-
-        unsafe {
-            (function)(
-                input.as_ptr() as *const c_void,
-                length as u32,
-                output.as_mut_ptr() as *mut c_void,
-                keys[0],
-                keys[1],
-                keys[2],
-                keys[3],
-            );
+            if result.read_u32(0) == 1 {
+                return Ok(keys.clone());
+            }
         }
 
-        Ok(output)
-    })
-}
-
-fn get_archive_header(
-    file: &mut File,
-    decrypt: &DecryptFn,
-    keys: &[u32; 4],
-) -> Result<(u16, u32, Vec<u8>)> {
-    let version = file.read_u16(100)?;
-    let mut file_count = file.read_u32(104)?;
-
-    if version > 2 {
-        file_count = file_count + file.read_u32(108)?;
+        bail!("Failed to find valid decryption key")
     }
 
-    let size = file_count.saturating_mul(512);
-    let input = file.read_bytes(512, size as usize)?;
-    let result = decrypt(&input, &keys)?;
+    fn load_decrypt_function() -> Result<impl Fn(&Vec<u8>, &[u32; 4]) -> Result<Vec<u8>>> {
+        // Load the 32-bit DLL
+        let dll_path = CString::new("defarm.dll").unwrap();
+        let h_module = unsafe { LoadLibraryA(dll_path.as_ptr()) };
+        if h_module == std::ptr::null_mut() {
+            panic!("Failed to load 'defarm.dll'");
+        }
 
-    Ok((version, file_count, result))
-}
+        // Get the function address
+        let func_name = CString::new("defarm").unwrap();
+        let func_ptr = unsafe { GetProcAddress(h_module, func_name.as_ptr()) };
+        if func_ptr.is_null() {
+            panic!("Failed to find function entry pointer to 'defarm' in 'defarm.dll'");
+        }
 
-fn main() -> Result<()> {
-    let cli: Cmd = argh::from_env();
+        let function: DefarmFn = unsafe { transmute(func_ptr) };
 
-    let decrypt = load_decrypt_function()?;
-    let mut file = File::open(cli.input)?;
-    let keys = find_keys(&mut file, &decrypt)?;
+        Ok(move |input: &Vec<u8>, keys: &[u32; 4]| {
+            let length = input.len();
+            let mut output: Vec<u8> = vec![0; length];
 
-    let signature = file.read_string(0, 20)?;
-    let identifier = file.read_string(96, 4)?;
-    let (version, file_count, header) = get_archive_header(&mut file, &decrypt, &keys)?;
+            unsafe {
+                (function)(
+                    input.as_ptr() as *const c_void,
+                    length as u32,
+                    output.as_mut_ptr() as *mut c_void,
+                    keys[0],
+                    keys[1],
+                    keys[2],
+                    keys[3],
+                );
+            }
 
-    println!(
-        "Using keys: {}
+            Ok(output)
+        })
+    }
+
+    fn get_archive_header(
+        file: &mut File,
+        decrypt: &DecryptFn,
+        keys: &[u32; 4],
+    ) -> Result<(u16, u32, Vec<u8>)> {
+        let version = file.read_u16(100)?;
+        let mut file_count = file.read_u32(104)?;
+
+        if version > 2 {
+            file_count = file_count + file.read_u32(108)?;
+        }
+
+        let size = file_count.saturating_mul(512);
+        let input = file.read_bytes(512, size as usize)?;
+        let result = decrypt(&input, &keys)?;
+
+        Ok((version, file_count, result))
+    }
+
+    pub fn run() -> Result<()> {
+        let cli: Cmd = argh::from_env();
+
+        let decrypt = load_decrypt_function()?;
+        let mut file = File::open(cli.input)?;
+        let keys = find_keys(&mut file, &decrypt)?;
+
+        let signature = file.read_string(0, 20)?;
+        let identifier = file.read_string(96, 4)?;
+        let (version, file_count, header) = get_archive_header(&mut file, &decrypt, &keys)?;
+
+        println!(
+            "Using keys: {}
 Signature: {}
 Identifier: {}
 Version: {}
 File count: {}",
-        byte_array_hex_string(&keys),
-        signature,
-        identifier,
-        version,
-        file_count
-    );
+            byte_array_hex_string(&keys),
+            signature,
+            identifier,
+            version,
+            file_count
+        );
 
-    ensure!(file_count > 0, "No file entries found in archive");
+        ensure!(file_count > 0, "No file entries found in archive");
 
-    for i in 0..file_count {
-        let offset = 512 * i as usize;
+        for i in 0..file_count {
+            let offset = 512 * i as usize;
 
-        let file_xsize = header.read_u32(offset + 8);
-        let file_size = header.read_u32(offset + 16);
-        let file_offset = header.read_u64(offset + 24);
-        let file_name = header.read_cstring(offset + 40)?;
+            let file_xsize = header.read_u32(offset + 8);
+            let file_size = header.read_u32(offset + 16);
+            let file_offset = header.read_u64(offset + 24);
+            let file_name = header.read_cstring(offset + 40)?;
 
-        let cipher_bytes = file.read_bytes(file_offset, file_xsize as usize)?;
-        let deciphered_bytes = decrypt(&cipher_bytes, &keys)?;
-        let file_bytes = deciphered_bytes[0..file_size as usize].to_vec();
+            let cipher_bytes = file.read_bytes(file_offset, file_xsize as usize)?;
+            let deciphered_bytes = decrypt(&cipher_bytes, &keys)?;
+            let file_bytes = deciphered_bytes[0..file_size as usize].to_vec();
 
-        let file_path: PathBuf = cli.output_path.join(&file_name).components().collect();
+            let file_path: PathBuf = cli.output_path.join(&file_name).components().collect();
 
-        file_bytes.write_to_file(&file_path)?;
+            file_bytes.write_to_file(&file_path)?;
 
-        println!("{}", file_path.display());
+            println!("{}", file_path.display());
+        }
+
+        Ok(())
     }
+}
 
-    Ok(())
+#[cfg(windows)]
+fn main() -> anyhow::Result<()> {
+    windows::run()
+}
+
+#[cfg(not(windows))]
+fn main() {
+    eprintln!("fs-unpack is only supported on Windows (requires defarm.dll)");
+    std::process::exit(1);
 }


### PR DESCRIPTION
## Summary
- `fs-patch-process` and `fs-unpack` now compile successfully on macOS and Linux
- Windows-specific code wrapped in `#[cfg(windows)]` modules
- `winapi` dependencies moved to `[target.'cfg(windows)'.dependencies]` sections
- Non-Windows builds produce binaries that exit with helpful error messages

## Changes
- **fs-patch-process**: Wrapped all Windows API code in a `#[cfg(windows)]` module
- **fs-unpack**: Wrapped all Windows DLL loading code in a `#[cfg(windows)]` module
- Both tools now build on all platforms but only function on Windows

## Test plan
- [x] Verified `cargo build` succeeds on macOS
- [x] Verify `cargo build` succeeds on Windows
- [x] Verify tools still work correctly on Windows