### PR TITLE
Add GAR archive support via gar-lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,8 @@ dependencies = [
  "anyhow",
  "argh",
  "fs-lib",
- "winapi",
+ "gar-lib",
+ "rayon",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +470,7 @@ dependencies = [
  "anyhow",
  "argh",
  "fs-lib",
+ "gar-lib",
  "lazy_static",
  "luau-lifter",
  "nom",
@@ -534,6 +546,14 @@ dependencies = [
  "argh",
  "fs-lib",
  "xml-rs",
+]
+
+[[package]]
+name = "gar-lib"
+version = "0.1.0"
+source = "git+https://github.com/Paint-a-Farm/gar-lib.git#e7e9cbccffde73179875eb8ab56953eb2fc7cc5e"
+dependencies = [
+ "vfs",
 ]
 
 [[package]]
@@ -657,6 +677,17 @@ checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
  "windows-link",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags",
+ "libc",
+ "redox_syscall 0.7.0",
 ]
 
 [[package]]
@@ -861,7 +892,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -946,6 +977,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
  "bitflags",
 ]
@@ -1246,6 +1286,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vfs"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e723b9e1c02a3cf9f9d0de6a4ddb8cdc1df859078902fe0ae0589d615711ae6"
+dependencies = [
+ "filetime",
+]
 
 [[package]]
 name = "walkdir"

--- a/README.md
+++ b/README.md
@@ -10,29 +10,26 @@ cargo build --release -p fs-luajit-decompile
 ```
 
 ## fs-luau-decompile
-Decode and decompile Luau bytecode files (FS25). Using medal decompiler.
+Decode and decompile Luau bytecode files (FS25). Embeds the [medal](https://github.com/scfmod/medal) decompiler.
+
+Supports reading directly from GAR/DLC archives:
 ```sh
-cargo run -p fs-luau-decompile -- <input> [<output>] [-r] [-s] [-d] [-l] [-t] [--num-threads <n>]
+# Single file from archive
+fs-luau-decompile dataS.gar/scripts/main.l64
+
+# Directory inside archive
+fs-luau-decompile -r dataS.gar/scripts/vehicles/ -o ./output/
+
+# Entire archive
+fs-luau-decompile -r dataS.gar -o ./output/
 ```
+
+```sh
+cargo run -p fs-luau-decompile -- <input> [<output>] [-r] [-s] [-d] [--num-threads <n>]
+```
+
 ```sh
 cargo build --release -p fs-luau-decompile
-```
-
-### Platform Support
-- **Windows**: Uses `bin/luau-lifter.exe`
-- **Mac/Linux**: Uses `bin/luau-lifter` (compile medal from [https://github.com/scfmod/medal](https://github.com/scfmod/medal)
-
-The binary is searched in this order:
-1. `LUAU_LIFTER_PATH` environment variable (if set)
-2. Same directory as the executable
-3. `bin/` subdirectory
-
-To build medal for Mac:
-```sh
-git clone https://github.com/scfmod/medal
-cd medal
-cargo +nightly build --release --bin luau-lifter
-cp target/release/luau-lifter /path/to/fs-utils/bin/
 ```
 
 ## fs-shapes-unlock

--- a/README.md
+++ b/README.md
@@ -42,21 +42,12 @@ cargo build --release -p fs-shapes-unlock
 ```
 
 ## fs-unpack
-Unpack archive using ``defarm.dll``. Only compiling and running 32-bit version works.
+Extract GAR/DLC archives. Cross-platform, no external dependencies.
 ```sh
-cargo run -p fs-unpack --target i686-pc-windows-msvc -- <input_file> <output_path>
+cargo run -p fs-unpack -- <archive> <output_path> [-s]
 ```
 ```sh
-cargo build --release -p fs-unpack --target i686-pc-windows-msvc
-```
-
-## fs-unpack-dll
-Extract ``defarm.dll`` from QuickBMS script file.
-```sh
-cargo run -p fs-unpack-dll -- <input_file> [<output_path>]
-```
-```sh
-cargo build --release -p fs-unpack-dll
+cargo build --release -p fs-unpack
 ```
 
 ## fs-xml-format

--- a/fs-luau-decompile/Cargo.toml
+++ b/fs-luau-decompile/Cargo.toml
@@ -13,3 +13,4 @@ nom-leb128 = "0.2.0"
 regex = "1.11.1"
 rayon = "1.11.0"
 luau-lifter = { path = "../medal/luau-lifter" }
+gar-lib = { git = "https://github.com/Paint-a-Farm/gar-lib.git" }

--- a/fs-luau-decompile/src/main.rs
+++ b/fs-luau-decompile/src/main.rs
@@ -3,6 +3,7 @@ use argh::FromArgs;
 use fs_lib::{
     LUAU_DECODE_TABLES, buffer::BufferExtension, list_files_with_extension, path::PathExtension,
 };
+use gar_lib::{GarArchive, GarPath};
 use rayon::{
     ThreadPoolBuilder,
     iter::{IntoParallelIterator, ParallelIterator},
@@ -104,81 +105,194 @@ fn decode_file<P: AsRef<Path>>(file: P) -> Result<Vec<u8>> {
     Ok(bytecode)
 }
 
+fn decompile_from_archive(archive: &GarArchive, path: &str) -> Result<Vec<u8>> {
+    let mut bytecode = archive
+        .read_file(path)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    match decompile_bytecode(&mut bytecode) {
+        Ok(result) => Ok(result),
+        Err(e) => bail!("{}: {}", path, e),
+    }
+}
+
+fn decode_from_archive(archive: &GarArchive, path: &str) -> Result<Vec<u8>> {
+    let mut bytecode = archive
+        .read_file(path)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    let (version, is_encoded, is_dlc) = get_bytecode_info(&bytecode);
+
+    if version == 0 {
+        bail!("Unsupported/unknown bytecode");
+    }
+
+    if is_encoded {
+        decode_bytecode(&mut bytecode, version, is_dlc)?;
+    }
+
+    Ok(bytecode)
+}
+
+fn list_l64_files<'a>(archive: &'a GarArchive, base: &str, recursive: bool) -> Vec<&'a str> {
+    archive
+        .files_with_extension(base, "l64", recursive)
+        .into_iter()
+        .filter(|f| !f.contains("XMLSchema.l64"))
+        .collect()
+}
+
 fn main() -> Result<()> {
     let cli: Cmd = argh::from_env();
 
-    if cli.input.is_file() {
-        let mut output_file: PathBuf = cli
-            .output
-            .unwrap_or(cli.input.clone())
-            .components()
-            .collect();
+    match GarPath::parse(&cli.input) {
+        GarPath::Filesystem(path) => {
+            if path.is_file() {
+                let mut output_file: PathBuf = cli
+                    .output
+                    .unwrap_or(path.clone())
+                    .components()
+                    .collect();
 
-        let result = match cli.decode_only {
-            false => {
-                if output_file.extension().unwrap() == "l64" {
-                    output_file.set_extension("lua");
+                let result = match cli.decode_only {
+                    false => {
+                        if output_file.extension().unwrap() == "l64" {
+                            output_file.set_extension("lua");
+                        }
+
+                        decompile_file(&path)?
+                    }
+                    true => decode_file(&path)?,
+                };
+
+                result.write_to_file(&output_file)?;
+
+                if !cli.silent {
+                    if output_file != path {
+                        println!("{} -> {}", path.display(), output_file.display());
+                    } else {
+                        println!("{}", path.display());
+                    }
+                }
+            } else if path.is_dir() {
+                let output_path = cli.output.unwrap_or_else(|| path.clone());
+
+                if output_path.is_file() {
+                    bail!("Output path is a file")
                 }
 
-                decompile_file(&cli.input)?
-            }
-            true => decode_file(&cli.input)?,
-        };
+                ThreadPoolBuilder::new()
+                    .num_threads(cli.num_threads.into())
+                    .build_global()
+                    .unwrap();
 
-        result.write_to_file(&output_file)?;
+                let files: Vec<_> = list_files_with_extension(&path, r"l64", cli.recursive)?
+                    .into_iter()
+                    .filter(|f| {
+                        let name = f.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                        !name.contains("XMLSchema")
+                    })
+                    .collect();
 
-        if !cli.silent {
-            if output_file != *cli.input {
-                println!("{} -> {}", cli.input.display(), output_file.display());
-            } else {
-                println!("{}", cli.input.display());
-            }
-        }
-    } else if cli.input.is_dir() {
-        let output_path = cli.output.unwrap_or_else(|| cli.input.clone());
+                let iter_result = files.into_par_iter().try_for_each(|file| -> Result<()> {
+                    let mut output_file: PathBuf = file
+                        .convert_relative_path(&path, &output_path)?
+                        .components()
+                        .collect();
 
-        if output_path.is_file() {
-            bail!("Output path is a file")
-        }
+                    let result = match cli.decode_only {
+                        false => {
+                            if output_file.extension().unwrap() == "l64" {
+                                output_file.set_extension("lua");
+                            }
 
-        ThreadPoolBuilder::new()
-            .num_threads(cli.num_threads.into())
-            .build_global()
-            .unwrap();
+                            decompile_file(&file)?
+                        }
+                        true => decode_file(&file)?,
+                    };
 
-        let files = list_files_with_extension(&cli.input, r"l64", cli.recursive)?;
+                    result.write_to_file(&output_file)?;
 
-        let iter_result = files.into_par_iter().try_for_each(|file| -> Result<()> {
-            let mut output_file: PathBuf = file
-                .convert_relative_path(&cli.input, &output_path)?
-                .components()
-                .collect();
-
-            let result = match cli.decode_only {
-                false => {
-                    if output_file.extension().unwrap() == "l64" {
-                        output_file.set_extension("lua");
+                    if !cli.silent {
+                        if output_file != *file {
+                            println!("{} -> {}", file.display(), output_file.display());
+                        } else {
+                            println!("{}", file.display());
+                        }
                     }
 
-                    decompile_file(&file)?
-                }
-                true => decode_file(&file)?,
-            };
+                    Ok(())
+                });
 
-            result.write_to_file(&output_file)?;
-
-            if !cli.silent {
-                if output_file != *file {
-                    println!("{} -> {}", file.display(), output_file.display());
-                } else {
-                    println!("{}", file.display());
-                }
+                return iter_result;
             }
+        }
+        GarPath::Archive {
+            archive_path,
+            internal_path,
+        } => {
+            let archive = GarArchive::open(&archive_path)
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
+            let base = internal_path.as_deref().unwrap_or("");
+            let output_path = cli.output.unwrap_or_else(|| PathBuf::from("."));
 
-            Ok(())
-        });
+            ThreadPoolBuilder::new()
+                .num_threads(cli.num_threads.into())
+                .build_global()
+                .unwrap();
 
-        return iter_result;
+            // Check if internal path is a single file
+            if base.ends_with(".l64") {
+                let result = if cli.decode_only {
+                    decode_from_archive(&archive, base)?
+                } else {
+                    decompile_from_archive(&archive, base)?
+                };
+
+                let filename = Path::new(base).file_name().unwrap();
+                let mut out_file = output_path.join(filename);
+                if !cli.decode_only {
+                    out_file.set_extension("lua");
+                }
+
+                result.write_to_file(&out_file)?;
+
+                if !cli.silent {
+                    println!("{} -> {}", base, out_file.display());
+                }
+            } else {
+                // Directory - process multiple files
+                let files = list_l64_files(&archive, base, cli.recursive);
+
+                if files.is_empty() {
+                    bail!("No .l64 files found in archive path: {}", base);
+                }
+
+                let iter_result = files.into_par_iter().try_for_each(|file| -> Result<()> {
+                    let result = if cli.decode_only {
+                        decode_from_archive(&archive, file)?
+                    } else {
+                        decompile_from_archive(&archive, file)?
+                    };
+
+                    let rel_path = file.strip_prefix(base).unwrap_or(file).trim_start_matches('/');
+                    let mut out_file = output_path.join(rel_path);
+                    if !cli.decode_only {
+                        out_file.set_extension("lua");
+                    }
+
+                    result.write_to_file(&out_file)?;
+
+                    if !cli.silent {
+                        println!("{} -> {}", file, out_file.display());
+                    }
+
+                    Ok(())
+                });
+
+                return iter_result;
+            }
+        }
     }
 
     Ok(())

--- a/fs-unpack/Cargo.toml
+++ b/fs-unpack/Cargo.toml
@@ -7,6 +7,5 @@ edition = "2024"
 anyhow = "1.0.99"
 argh = "0.1.13"
 fs-lib = { version = "1.0.0", path = "../fs-lib" }
-
-[target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["libloaderapi"] }
+gar-lib = { git = "https://github.com/Paint-a-Farm/gar-lib.git" }
+rayon = "1.11.0"

--- a/fs-unpack/src/main.rs
+++ b/fs-unpack/src/main.rs
@@ -1,168 +1,66 @@
-#[cfg(windows)]
-mod windows {
-    use std::{
-        ffi::{CString, c_uint, c_void},
-        fs::File,
-        mem::transmute,
-        path::PathBuf,
-    };
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
-    use winapi::um::libloaderapi::{GetProcAddress, LoadLibraryA};
+use anyhow::{Result, bail};
+use argh::FromArgs;
+use fs_lib::buffer::BufferExtension;
+use gar_lib::GarArchive;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
-    use anyhow::{Result, bail, ensure};
-    use argh::FromArgs;
-    use fs_lib::{KEYS_LIST, buffer::BufferExtension, byte_array_hex_string, file::FileExtension};
+#[derive(FromArgs, PartialEq, Debug)]
+/// Extract .gar/.dlc archive
+struct Cmd {
+    /// silent mode
+    #[argh(switch, short = 's')]
+    silent: bool,
 
-    #[derive(FromArgs, PartialEq, Debug)]
-    /// Extract .gar/.pdlc archive
-    pub struct Cmd {
-        /// path to .gar/.pdlc archive
-        #[argh(positional)]
-        input: PathBuf,
+    /// path to .gar/.dlc archive
+    #[argh(positional)]
+    input: PathBuf,
 
-        /// output path
-        #[argh(positional)]
-        output_path: PathBuf,
+    /// output path
+    #[argh(positional)]
+    output_path: PathBuf,
+}
+
+fn main() -> Result<()> {
+    let cli: Cmd = argh::from_env();
+
+    let archive = GarArchive::open(&cli.input)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    let file_count = archive.len();
+
+    if file_count == 0 {
+        bail!("No files found in archive");
     }
 
-    type DefarmFn = unsafe extern "C" fn(
-        input: *const c_void,
-        input_size: c_uint,
-        output: *mut c_void,
-        key1: c_uint,
-        key2: c_uint,
-        key3: c_uint,
-        key4: c_uint,
-    );
-
-    type DecryptFn = dyn Fn(&Vec<u8>, &[u32; 4]) -> Result<Vec<u8>>;
-
-    fn find_keys(file: &mut File, decrypt_fn: &DecryptFn) -> Result<[u32; 4]> {
-        let test_bytes = file.read_bytes(512, 8)?;
-
-        for keys in KEYS_LIST.iter() {
-            let result = decrypt_fn(&test_bytes, &keys)?;
-
-            if result.read_u32(0) == 1 {
-                return Ok(keys.clone());
-            }
-        }
-
-        bail!("Failed to find valid decryption key")
+    if !cli.silent {
+        println!("Extracting {} files from {}", file_count, cli.input.display());
     }
 
-    fn load_decrypt_function() -> Result<impl Fn(&Vec<u8>, &[u32; 4]) -> Result<Vec<u8>>> {
-        // Load the 32-bit DLL
-        let dll_path = CString::new("defarm.dll").unwrap();
-        let h_module = unsafe { LoadLibraryA(dll_path.as_ptr()) };
-        if h_module == std::ptr::null_mut() {
-            panic!("Failed to load 'defarm.dll'");
-        }
+    let files: Vec<_> = archive.files().collect();
+    let extracted = AtomicUsize::new(0);
 
-        // Get the function address
-        let func_name = CString::new("defarm").unwrap();
-        let func_ptr = unsafe { GetProcAddress(h_module, func_name.as_ptr()) };
-        if func_ptr.is_null() {
-            panic!("Failed to find function entry pointer to 'defarm' in 'defarm.dll'");
-        }
+    files.into_par_iter().try_for_each(|file_name| -> Result<()> {
+        let data = archive.read_file(file_name)
+            .map_err(|e| anyhow::anyhow!("{}", e))?;
 
-        let function: DefarmFn = unsafe { transmute(func_ptr) };
+        let file_path: PathBuf = cli.output_path.join(file_name).components().collect();
 
-        Ok(move |input: &Vec<u8>, keys: &[u32; 4]| {
-            let length = input.len();
-            let mut output: Vec<u8> = vec![0; length];
+        data.write_to_file(&file_path)?;
 
-            unsafe {
-                (function)(
-                    input.as_ptr() as *const c_void,
-                    length as u32,
-                    output.as_mut_ptr() as *mut c_void,
-                    keys[0],
-                    keys[1],
-                    keys[2],
-                    keys[3],
-                );
-            }
-
-            Ok(output)
-        })
-    }
-
-    fn get_archive_header(
-        file: &mut File,
-        decrypt: &DecryptFn,
-        keys: &[u32; 4],
-    ) -> Result<(u16, u32, Vec<u8>)> {
-        let version = file.read_u16(100)?;
-        let mut file_count = file.read_u32(104)?;
-
-        if version > 2 {
-            file_count = file_count + file.read_u32(108)?;
-        }
-
-        let size = file_count.saturating_mul(512);
-        let input = file.read_bytes(512, size as usize)?;
-        let result = decrypt(&input, &keys)?;
-
-        Ok((version, file_count, result))
-    }
-
-    pub fn run() -> Result<()> {
-        let cli: Cmd = argh::from_env();
-
-        let decrypt = load_decrypt_function()?;
-        let mut file = File::open(cli.input)?;
-        let keys = find_keys(&mut file, &decrypt)?;
-
-        let signature = file.read_string(0, 20)?;
-        let identifier = file.read_string(96, 4)?;
-        let (version, file_count, header) = get_archive_header(&mut file, &decrypt, &keys)?;
-
-        println!(
-            "Using keys: {}
-Signature: {}
-Identifier: {}
-Version: {}
-File count: {}",
-            byte_array_hex_string(&keys),
-            signature,
-            identifier,
-            version,
-            file_count
-        );
-
-        ensure!(file_count > 0, "No file entries found in archive");
-
-        for i in 0..file_count {
-            let offset = 512 * i as usize;
-
-            let file_xsize = header.read_u32(offset + 8);
-            let file_size = header.read_u32(offset + 16);
-            let file_offset = header.read_u64(offset + 24);
-            let file_name = header.read_cstring(offset + 40)?;
-
-            let cipher_bytes = file.read_bytes(file_offset, file_xsize as usize)?;
-            let deciphered_bytes = decrypt(&cipher_bytes, &keys)?;
-            let file_bytes = deciphered_bytes[0..file_size as usize].to_vec();
-
-            let file_path: PathBuf = cli.output_path.join(&file_name).components().collect();
-
-            file_bytes.write_to_file(&file_path)?;
-
-            println!("{}", file_path.display());
+        let count = extracted.fetch_add(1, Ordering::Relaxed) + 1;
+        if !cli.silent && count % 500 == 0 {
+            println!("Extracted {}/{} files...", count, file_count);
         }
 
         Ok(())
+    })?;
+
+    if !cli.silent {
+        println!("Done. Extracted {} files.", file_count);
     }
-}
 
-#[cfg(windows)]
-fn main() -> anyhow::Result<()> {
-    windows::run()
-}
-
-#[cfg(not(windows))]
-fn main() {
-    eprintln!("fs-unpack is only supported on Windows (requires defarm.dll)");
-    std::process::exit(1);
+    Ok(())
 }


### PR DESCRIPTION
## Summary

- **fs-luau-decompile**: Read and decompile .l64 files directly from GAR/DLC archives
- **fs-unpack**: Complete rewrite using pure Rust gar-lib (cross-platform, no more defarm.dll)

## Changes

### fs-luau-decompile
- Support archive paths like `dataS.gar/scripts/main.l64`
- Process single files, directories, or entire archives
- Uses `GarPath` for transparent filesystem/archive path handling

### fs-unpack
- Pure Rust implementation via gar-lib
- Works on macOS/Linux/Windows (no 32-bit Windows requirement)
- Parallel extraction with rayon (~8s for 5889 files)
- Removed fs-unpack-dll from README (no longer needed)

## Usage

```sh
# Decompile single file from archive
fs-luau-decompile dataS.gar/scripts/main.l64

# Decompile entire archive
fs-luau-decompile -r dataS.gar -o ./output/

# Extract archive
fs-unpack dataS.gar ./output/
```