### PR TITLE
Increase rayon thread stack size for lantern

### DIFF
--- a/fs-luau-decompile/src/main.rs
+++ b/fs-luau-decompile/src/main.rs
@@ -255,6 +255,7 @@ fn main() -> Result<()> {
 
                 ThreadPoolBuilder::new()
                     .num_threads(cli.num_threads.into())
+                    .stack_size(32 * 1024 * 1024)
                     .build_global()
                     .unwrap();
 
@@ -309,6 +310,7 @@ fn main() -> Result<()> {
 
             ThreadPoolBuilder::new()
                 .num_threads(cli.num_threads.into())
+                .stack_size(32 * 1024 * 1024)
                 .build_global()
                 .unwrap();
 


### PR DESCRIPTION
## Summary
- Set rayon thread pool stack size to 32MB (matching lantern CLI's own stack size)
- Fixes stack overflow when using `--lantern` on deeply nested scripts
- Applied to both filesystem and GAR archive code paths

## Test plan
- [x] Full corpus decompile with `--lantern` (1832 files, no crashes)
- [x] Previously crashed on ~15th file with `thread has overflowed its stack`

🤖 Generated with [Claude Code](https://claude.com/claude-code)