### PR TITLE
Switch fs-luau-decompile to lantern as sole decompiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,170 +3,56 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "anstream"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
-dependencies = [
- "backtrace",
-]
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "argh"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ff18325c8a36b82f992e533ece1ec9f9a9db446bd1c14d4f936bac88fcd240"
+checksum = "7f384d96bfd3c0b3c41f24dae69ee9602c091d64fc432225cf5295b5abbe0036"
 dependencies = [
  "argh_derive",
  "argh_shared",
- "rust-fuzzy-search",
 ]
 
 [[package]]
 name = "argh_derive"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb7b2b83a50d329d5d8ccc620f5c7064028828538bdf5646acd60dc1f767803"
+checksum = "938e5f66269c1f168035e29ed3fb437b084e476465e9314a0328f4005d7be599"
 dependencies = [
  "argh_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "argh_shared"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a464143cc82dedcdc3928737445362466b7674b5db4e2eb8e869846d6d84f4f6"
+checksum = "5127f8a5bc1cfb0faf1f6248491452b8a5b6901068d8da2d47cbb285986ae683"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "array_tool"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f8cb5d814eb646a863c4f24978cff2880c4be96ad8cde2c0f0678732902e271"
 
 [[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "ast"
-version = "0.1.0"
-source = "git+https://github.com/scfmod/medal.git#51f217b850548a9613242c707452b3de04bb072a"
-dependencies = [
- "array_tool",
- "by_address",
- "derive_more 0.99.20",
- "enum-as-inner",
- "enum_dispatch",
- "indexmap 1.9.3",
- "itertools",
- "itoa",
- "nohash-hasher",
- "parking_lot",
- "petgraph 0.6.3",
- "rustc-hash 1.1.0",
- "ryu",
- "triomphe",
-]
 
 [[package]]
 name = "atty"
@@ -186,21 +72,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,9 +79,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "borsh"
@@ -238,12 +109,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "by_address"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
-
-[[package]]
 name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,33 +116,12 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "cc"
-version = "1.2.52"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "shlex",
-]
-
-[[package]]
-name = "cfg"
-version = "0.1.0"
-source = "git+https://github.com/scfmod/medal.git#51f217b850548a9613242c707452b3de04bb072a"
-dependencies = [
- "array_tool",
- "ast",
- "contracts",
- "dot",
- "enum-as-inner",
- "enum_dispatch",
- "hashlink",
- "indexmap 1.9.3",
- "itertools",
- "petgraph 0.6.3",
- "rangemap",
- "rustc-hash 1.1.0",
- "thiserror",
- "tuple",
 ]
 
 [[package]]
@@ -300,35 +144,13 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags 1.3.2",
- "clap_derive 3.2.25",
- "clap_lex 0.2.4",
+ "clap_derive",
+ "clap_lex",
  "indexmap 1.9.3",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
  "textwrap",
-]
-
-[[package]]
-name = "clap"
-version = "4.5.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
-dependencies = [
- "clap_builder",
- "clap_derive 4.5.49",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex 0.7.7",
- "strsim 0.11.1",
 ]
 
 [[package]]
@@ -337,23 +159,11 @@ version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
 ]
 
 [[package]]
@@ -364,18 +174,6 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
-
-[[package]]
-name = "clap_lex"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "console"
@@ -389,23 +187,6 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "contracts"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008eb94d541da40512913ef5e0707c3fb0e7280ba1af13f062461e46dd96ef7e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "crossbeam-channel"
@@ -443,19 +224,6 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "derive_more"
-version = "0.99.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
@@ -471,31 +239,9 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
  "unicode-xid",
 ]
-
-[[package]]
-name = "dhat"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
-dependencies = [
- "backtrace",
- "lazy_static",
- "mintex",
- "parking_lot",
- "rustc-hash 1.1.0",
- "serde",
- "serde_json",
- "thousands",
-]
-
-[[package]]
-name = "dot"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a74b6c4d4a1cff5f454164363c16b72fa12463ca6b31f4b5f2035a65fa3d5906"
 
 [[package]]
 name = "ec4rs"
@@ -514,30 +260,6 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
-
-[[package]]
-name = "enum-as-inner"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "enum_dispatch"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
-dependencies = [
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
 
 [[package]]
 name = "env_logger"
@@ -567,15 +289,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -627,12 +343,10 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "argh",
- "ast",
  "fs-lib",
  "gar-lib",
  "lantern",
  "lazy_static",
- "luau-lifter",
  "nom 7.1.3",
  "nom-leb128",
  "rayon",
@@ -696,7 +410,7 @@ checksum = "40373a6bf84c41c6124c01cbedf5ab53d0d468adf1c0d7efd4c3273531fbb609"
 dependencies = [
  "bytecount",
  "cfg-if",
- "derive_more 1.0.0",
+ "derive_more",
  "full_moon_derive",
  "paste",
  "serde",
@@ -717,17 +431,11 @@ dependencies = [
 
 [[package]]
 name = "gar-lib"
-version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/gar-lib.git#e7e9cbccffde73179875eb8ab56953eb2fc7cc5e"
+version = "0.2.0"
+source = "git+https://github.com/Paint-a-Farm/gar-lib.git#7575d5f890aeb2198077646241f88cd73f013ab6"
 dependencies = [
  "vfs",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "globset"
@@ -750,40 +458,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "hashlink"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
-dependencies = [
- "hashbrown 0.14.5",
-]
 
 [[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -837,21 +520,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,7 +528,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 [[package]]
 name = "lantern"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#1fa3ed145c2c2bfccb8f569692ec98c4de4ddfdb"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#711417241006f674e34a3e100912fe79827a974d"
 dependencies = [
  "lantern-bytecode",
  "lantern-emit",
@@ -875,7 +543,7 @@ dependencies = [
 [[package]]
 name = "lantern-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#1fa3ed145c2c2bfccb8f569692ec98c4de4ddfdb"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#711417241006f674e34a3e100912fe79827a974d"
 dependencies = [
  "anyhow",
  "nom 8.0.0",
@@ -884,64 +552,64 @@ dependencies = [
 [[package]]
 name = "lantern-emit"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#1fa3ed145c2c2bfccb8f569692ec98c4de4ddfdb"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#711417241006f674e34a3e100912fe79827a974d"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",
- "petgraph 0.7.1",
- "rustc-hash 2.1.1",
+ "petgraph",
+ "rustc-hash",
 ]
 
 [[package]]
 name = "lantern-exprs"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#1fa3ed145c2c2bfccb8f569692ec98c4de4ddfdb"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#711417241006f674e34a3e100912fe79827a974d"
 dependencies = [
  "lantern-hir",
- "petgraph 0.7.1",
- "rustc-hash 2.1.1",
+ "petgraph",
+ "rustc-hash",
 ]
 
 [[package]]
 name = "lantern-hir"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#1fa3ed145c2c2bfccb8f569692ec98c4de4ddfdb"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#711417241006f674e34a3e100912fe79827a974d"
 dependencies = [
  "lantern-bytecode",
- "petgraph 0.7.1",
- "rustc-hash 2.1.1",
+ "petgraph",
+ "rustc-hash",
 ]
 
 [[package]]
 name = "lantern-lift"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#1fa3ed145c2c2bfccb8f569692ec98c4de4ddfdb"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#711417241006f674e34a3e100912fe79827a974d"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",
- "petgraph 0.7.1",
- "rustc-hash 2.1.1",
+ "petgraph",
+ "rustc-hash",
 ]
 
 [[package]]
 name = "lantern-structure"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#1fa3ed145c2c2bfccb8f569692ec98c4de4ddfdb"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#711417241006f674e34a3e100912fe79827a974d"
 dependencies = [
  "lantern-hir",
- "petgraph 0.7.1",
- "rustc-hash 2.1.1",
+ "petgraph",
+ "rustc-hash",
 ]
 
 [[package]]
 name = "lantern-vars"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#1fa3ed145c2c2bfccb8f569692ec98c4de4ddfdb"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#711417241006f674e34a3e100912fe79827a974d"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",
- "petgraph 0.7.1",
- "rustc-hash 2.1.1",
+ "petgraph",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -952,9 +620,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libloading"
@@ -972,9 +640,9 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
- "redox_syscall 0.7.0",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -1029,33 +697,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "luau-lifter"
-version = "0.1.0"
-source = "git+https://github.com/scfmod/medal.git#51f217b850548a9613242c707452b3de04bb072a"
-dependencies = [
- "anyhow",
- "ast",
- "by_address",
- "cfg",
- "clap 4.5.54",
- "dhat",
- "either",
- "indexmap 1.9.3",
- "itertools",
- "lazy_static",
- "nom 7.1.3",
- "nom-leb128",
- "num_enum",
- "parking_lot",
- "petgraph 0.6.3",
- "rayon",
- "restructure",
- "rustc-hash 1.1.0",
- "triomphe",
- "walkdir",
-]
-
-[[package]]
 name = "luau0-src"
 version = "0.12.3+luau663"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,30 +707,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
-]
-
-[[package]]
-name = "mintex"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mlua"
@@ -1103,7 +729,7 @@ dependencies = [
  "mlua-sys",
  "num-traits",
  "parking_lot",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustversion",
 ]
 
@@ -1118,12 +744,6 @@ dependencies = [
  "luau0-src",
  "pkg-config",
 ]
-
-[[package]]
-name = "nohash-hasher"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -1175,46 +795,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
-dependencies = [
- "num_enum_derive",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "os_str_bytes"
@@ -1253,20 +837,11 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "petgraph"
-version = "0.6.3"
-source = "git+https://github.com/jujhar16/petgraph.git?branch=ensure_len_resize_with#b40d963eed74f870f83a863806183259b659e525"
-dependencies = [
- "fixedbitset 0.4.2",
- "indexmap 1.9.3",
-]
-
-[[package]]
-name = "petgraph"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
- "fixedbitset 0.5.7",
+ "fixedbitset",
  "indexmap 2.13.0",
 ]
 
@@ -1275,16 +850,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
-]
 
 [[package]]
 name = "proc-macro-error"
@@ -1312,27 +877,21 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "rangemap"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "rayon"
@@ -1360,23 +919,23 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1386,9 +945,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1397,45 +956,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.6"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
-
-[[package]]
-name = "restructure"
-version = "0.1.0"
-source = "git+https://github.com/scfmod/medal.git#51f217b850548a9613242c707452b3de04bb072a"
-dependencies = [
- "array_tool",
- "ast",
- "cfg",
- "derive_more 0.99.20",
- "enum-as-inner",
- "itertools",
- "parking_lot",
- "petgraph 0.6.3",
- "rustc-hash 1.1.0",
- "triomphe",
- "tuple",
-]
-
-[[package]]
-name = "rust-fuzzy-search"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a157657054ffe556d8858504af8a672a054a6e0bd9e8ee531059100c0fa11bb2"
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustc-hash"
@@ -1444,25 +967,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "same-file"
@@ -1480,41 +988,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "semver"
-version = "1.0.27"
+name = "serde"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
 
 [[package]]
-name = "serde"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1525,7 +1038,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1561,31 +1074,19 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smol_str"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9676b89cd56310a87b93dec47b11af744f34d5fc9f367b829474eec0a891350d"
+checksum = "0f7a918bd2a9951d18ee6e48f076843e8e73a9a5d22cf05bcd4b7a81bdd04e17"
 dependencies = [
  "borsh",
- "serde",
+ "serde_core",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "stylua"
@@ -1595,7 +1096,7 @@ checksum = "9bc8bced01d9eed87b595290bd6e1767691404d7607c6fca001453a032ce8eb6"
 dependencies = [
  "anyhow",
  "cfg-if",
- "clap 3.2.25",
+ "clap",
  "console",
  "crossbeam-channel",
  "ec4rs",
@@ -1632,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1673,14 +1174,8 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
-
-[[package]]
-name = "thousands"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "threadpool"
@@ -1700,7 +1195,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.27",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1714,17 +1209,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.13.0",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
@@ -1734,7 +1218,7 @@ dependencies = [
  "serde_spanned",
  "toml_datetime",
  "toml_write",
- "winnow 0.7.14",
+ "winnow",
 ]
 
 [[package]]
@@ -1744,30 +1228,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
-name = "triomphe"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
-dependencies = [
- "serde",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "tuple"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb9f6bd73479481158ba8ee3edf17aca93354623d13f02e96a2014fdbc1c37e"
-dependencies = [
- "num-traits",
- "serde",
-]
-
-[[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-width"
@@ -1780,12 +1244,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"
@@ -1814,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.110"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de241cdc66a9d91bd84f097039eb140cdc6eec47e0cdbaf9d932a1dd6c35866"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1827,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.110"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12fdf6649048f2e3de6d7d5ff3ced779cdedee0e0baffd7dff5cdfa3abc8a52"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1837,22 +1295,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.110"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e63d1795c565ac3462334c1e396fd46dbf481c40f51f5072c310717bc4fb309"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.110"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f9cdac23a5ce71f6bf9f8824898a501e511892791ea2a0c6b8568c68b9cb53"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -1978,15 +1436,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
@@ -1996,9 +1445,9 @@ dependencies = [
 
 [[package]]
 name = "xml"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "838dd679b10a4180431ce7c2caa6e5585a7c8f63154c19ae99345126572e80cc"
+checksum = "b8aa498d22c9bbaf482329839bc5620c46be275a19a812e9a22a2b07529a642a"
 
 [[package]]
 name = "xml-rs"
@@ -2010,21 +1459,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.8.34"
+name = "zmij"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ddd76bcebeed25db614f82bf31a9f4222d3fbba300e6fb6c00afa26cbd4d9d"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8187381b52e32220d50b255276aa16a084ec0a9017a0ca2152a1f55c539758d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 [[package]]
 name = "lantern"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#eef391999aaba9d206bef76dfe21fdca686a9977"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b019f839cc16890ef418ee8211c06e5ad97134f1"
 dependencies = [
  "lantern-bytecode",
  "lantern-emit",
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "lantern-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#eef391999aaba9d206bef76dfe21fdca686a9977"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b019f839cc16890ef418ee8211c06e5ad97134f1"
 dependencies = [
  "anyhow",
  "nom 8.0.0",
@@ -552,7 +552,7 @@ dependencies = [
 [[package]]
 name = "lantern-emit"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#eef391999aaba9d206bef76dfe21fdca686a9977"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b019f839cc16890ef418ee8211c06e5ad97134f1"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",
@@ -563,7 +563,7 @@ dependencies = [
 [[package]]
 name = "lantern-exprs"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#eef391999aaba9d206bef76dfe21fdca686a9977"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b019f839cc16890ef418ee8211c06e5ad97134f1"
 dependencies = [
  "lantern-hir",
  "petgraph",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "lantern-hir"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#eef391999aaba9d206bef76dfe21fdca686a9977"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b019f839cc16890ef418ee8211c06e5ad97134f1"
 dependencies = [
  "lantern-bytecode",
  "petgraph",
@@ -583,7 +583,7 @@ dependencies = [
 [[package]]
 name = "lantern-lift"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#eef391999aaba9d206bef76dfe21fdca686a9977"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b019f839cc16890ef418ee8211c06e5ad97134f1"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",
@@ -594,7 +594,7 @@ dependencies = [
 [[package]]
 name = "lantern-structure"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#eef391999aaba9d206bef76dfe21fdca686a9977"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b019f839cc16890ef418ee8211c06e5ad97134f1"
 dependencies = [
  "lantern-hir",
  "petgraph",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "lantern-vars"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#eef391999aaba9d206bef76dfe21fdca686a9977"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b019f839cc16890ef418ee8211c06e5ad97134f1"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 [[package]]
 name = "lantern"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#b8d44dd5a5a6e1e3f873750ebfa119e8956721d2"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b68b81db3d261df80363b325e53761d3d49779a1"
 dependencies = [
  "lantern-bytecode",
  "lantern-emit",
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "lantern-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#b8d44dd5a5a6e1e3f873750ebfa119e8956721d2"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b68b81db3d261df80363b325e53761d3d49779a1"
 dependencies = [
  "anyhow",
  "nom 8.0.0",
@@ -552,7 +552,7 @@ dependencies = [
 [[package]]
 name = "lantern-emit"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#b8d44dd5a5a6e1e3f873750ebfa119e8956721d2"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b68b81db3d261df80363b325e53761d3d49779a1"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",
@@ -563,7 +563,7 @@ dependencies = [
 [[package]]
 name = "lantern-exprs"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#b8d44dd5a5a6e1e3f873750ebfa119e8956721d2"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b68b81db3d261df80363b325e53761d3d49779a1"
 dependencies = [
  "lantern-hir",
  "petgraph",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "lantern-hir"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#b8d44dd5a5a6e1e3f873750ebfa119e8956721d2"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b68b81db3d261df80363b325e53761d3d49779a1"
 dependencies = [
  "lantern-bytecode",
  "petgraph",
@@ -583,7 +583,7 @@ dependencies = [
 [[package]]
 name = "lantern-lift"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#b8d44dd5a5a6e1e3f873750ebfa119e8956721d2"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b68b81db3d261df80363b325e53761d3d49779a1"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",
@@ -594,7 +594,7 @@ dependencies = [
 [[package]]
 name = "lantern-structure"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#b8d44dd5a5a6e1e3f873750ebfa119e8956721d2"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b68b81db3d261df80363b325e53761d3d49779a1"
 dependencies = [
  "lantern-hir",
  "petgraph",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "lantern-vars"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#b8d44dd5a5a6e1e3f873750ebfa119e8956721d2"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b68b81db3d261df80363b325e53761d3d49779a1"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 [[package]]
 name = "lantern"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#f7dc6e243029cb2373987ceb1e4d9d07f1dbdd9f"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b1259d400c530b243428fc78c2d68e81c898120a"
 dependencies = [
  "lantern-bytecode",
  "lantern-emit",
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "lantern-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#f7dc6e243029cb2373987ceb1e4d9d07f1dbdd9f"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b1259d400c530b243428fc78c2d68e81c898120a"
 dependencies = [
  "anyhow",
  "nom 8.0.0",
@@ -552,7 +552,7 @@ dependencies = [
 [[package]]
 name = "lantern-emit"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#f7dc6e243029cb2373987ceb1e4d9d07f1dbdd9f"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b1259d400c530b243428fc78c2d68e81c898120a"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",
@@ -563,7 +563,7 @@ dependencies = [
 [[package]]
 name = "lantern-exprs"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#f7dc6e243029cb2373987ceb1e4d9d07f1dbdd9f"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b1259d400c530b243428fc78c2d68e81c898120a"
 dependencies = [
  "lantern-hir",
  "petgraph",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "lantern-hir"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#f7dc6e243029cb2373987ceb1e4d9d07f1dbdd9f"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b1259d400c530b243428fc78c2d68e81c898120a"
 dependencies = [
  "lantern-bytecode",
  "petgraph",
@@ -583,7 +583,7 @@ dependencies = [
 [[package]]
 name = "lantern-lift"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#f7dc6e243029cb2373987ceb1e4d9d07f1dbdd9f"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b1259d400c530b243428fc78c2d68e81c898120a"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",
@@ -594,7 +594,7 @@ dependencies = [
 [[package]]
 name = "lantern-structure"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#f7dc6e243029cb2373987ceb1e4d9d07f1dbdd9f"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b1259d400c530b243428fc78c2d68e81c898120a"
 dependencies = [
  "lantern-hir",
  "petgraph",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "lantern-vars"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#f7dc6e243029cb2373987ceb1e4d9d07f1dbdd9f"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b1259d400c530b243428fc78c2d68e81c898120a"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 [[package]]
 name = "lantern"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#2fd6a59894512e4011d024de6123d88d3963f391"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#f7dc6e243029cb2373987ceb1e4d9d07f1dbdd9f"
 dependencies = [
  "lantern-bytecode",
  "lantern-emit",
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "lantern-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#2fd6a59894512e4011d024de6123d88d3963f391"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#f7dc6e243029cb2373987ceb1e4d9d07f1dbdd9f"
 dependencies = [
  "anyhow",
  "nom 8.0.0",
@@ -552,7 +552,7 @@ dependencies = [
 [[package]]
 name = "lantern-emit"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#2fd6a59894512e4011d024de6123d88d3963f391"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#f7dc6e243029cb2373987ceb1e4d9d07f1dbdd9f"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",
@@ -563,7 +563,7 @@ dependencies = [
 [[package]]
 name = "lantern-exprs"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#2fd6a59894512e4011d024de6123d88d3963f391"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#f7dc6e243029cb2373987ceb1e4d9d07f1dbdd9f"
 dependencies = [
  "lantern-hir",
  "petgraph",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "lantern-hir"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#2fd6a59894512e4011d024de6123d88d3963f391"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#f7dc6e243029cb2373987ceb1e4d9d07f1dbdd9f"
 dependencies = [
  "lantern-bytecode",
  "petgraph",
@@ -583,7 +583,7 @@ dependencies = [
 [[package]]
 name = "lantern-lift"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#2fd6a59894512e4011d024de6123d88d3963f391"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#f7dc6e243029cb2373987ceb1e4d9d07f1dbdd9f"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",
@@ -594,7 +594,7 @@ dependencies = [
 [[package]]
 name = "lantern-structure"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#2fd6a59894512e4011d024de6123d88d3963f391"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#f7dc6e243029cb2373987ceb1e4d9d07f1dbdd9f"
 dependencies = [
  "lantern-hir",
  "petgraph",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "lantern-vars"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#2fd6a59894512e4011d024de6123d88d3963f391"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#f7dc6e243029cb2373987ceb1e4d9d07f1dbdd9f"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 [[package]]
 name = "lantern"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#6bd948659bae918c9f0b2f57beaaaf09ddeee269"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#2fd6a59894512e4011d024de6123d88d3963f391"
 dependencies = [
  "lantern-bytecode",
  "lantern-emit",
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "lantern-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#6bd948659bae918c9f0b2f57beaaaf09ddeee269"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#2fd6a59894512e4011d024de6123d88d3963f391"
 dependencies = [
  "anyhow",
  "nom 8.0.0",
@@ -552,7 +552,7 @@ dependencies = [
 [[package]]
 name = "lantern-emit"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#6bd948659bae918c9f0b2f57beaaaf09ddeee269"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#2fd6a59894512e4011d024de6123d88d3963f391"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",
@@ -563,7 +563,7 @@ dependencies = [
 [[package]]
 name = "lantern-exprs"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#6bd948659bae918c9f0b2f57beaaaf09ddeee269"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#2fd6a59894512e4011d024de6123d88d3963f391"
 dependencies = [
  "lantern-hir",
  "petgraph",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "lantern-hir"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#6bd948659bae918c9f0b2f57beaaaf09ddeee269"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#2fd6a59894512e4011d024de6123d88d3963f391"
 dependencies = [
  "lantern-bytecode",
  "petgraph",
@@ -583,7 +583,7 @@ dependencies = [
 [[package]]
 name = "lantern-lift"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#6bd948659bae918c9f0b2f57beaaaf09ddeee269"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#2fd6a59894512e4011d024de6123d88d3963f391"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",
@@ -594,7 +594,7 @@ dependencies = [
 [[package]]
 name = "lantern-structure"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#6bd948659bae918c9f0b2f57beaaaf09ddeee269"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#2fd6a59894512e4011d024de6123d88d3963f391"
 dependencies = [
  "lantern-hir",
  "petgraph",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "lantern-vars"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#6bd948659bae918c9f0b2f57beaaaf09ddeee269"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#2fd6a59894512e4011d024de6123d88d3963f391"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 [[package]]
 name = "lantern"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#711417241006f674e34a3e100912fe79827a974d"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#6bd948659bae918c9f0b2f57beaaaf09ddeee269"
 dependencies = [
  "lantern-bytecode",
  "lantern-emit",
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "lantern-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#711417241006f674e34a3e100912fe79827a974d"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#6bd948659bae918c9f0b2f57beaaaf09ddeee269"
 dependencies = [
  "anyhow",
  "nom 8.0.0",
@@ -552,7 +552,7 @@ dependencies = [
 [[package]]
 name = "lantern-emit"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#711417241006f674e34a3e100912fe79827a974d"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#6bd948659bae918c9f0b2f57beaaaf09ddeee269"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",
@@ -563,7 +563,7 @@ dependencies = [
 [[package]]
 name = "lantern-exprs"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#711417241006f674e34a3e100912fe79827a974d"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#6bd948659bae918c9f0b2f57beaaaf09ddeee269"
 dependencies = [
  "lantern-hir",
  "petgraph",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "lantern-hir"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#711417241006f674e34a3e100912fe79827a974d"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#6bd948659bae918c9f0b2f57beaaaf09ddeee269"
 dependencies = [
  "lantern-bytecode",
  "petgraph",
@@ -583,7 +583,7 @@ dependencies = [
 [[package]]
 name = "lantern-lift"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#711417241006f674e34a3e100912fe79827a974d"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#6bd948659bae918c9f0b2f57beaaaf09ddeee269"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",
@@ -594,7 +594,7 @@ dependencies = [
 [[package]]
 name = "lantern-structure"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#711417241006f674e34a3e100912fe79827a974d"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#6bd948659bae918c9f0b2f57beaaaf09ddeee269"
 dependencies = [
  "lantern-hir",
  "petgraph",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "lantern-vars"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#711417241006f674e34a3e100912fe79827a974d"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#6bd948659bae918c9f0b2f57beaaaf09ddeee269"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 [[package]]
 name = "lantern"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#b019f839cc16890ef418ee8211c06e5ad97134f1"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b8d44dd5a5a6e1e3f873750ebfa119e8956721d2"
 dependencies = [
  "lantern-bytecode",
  "lantern-emit",
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "lantern-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#b019f839cc16890ef418ee8211c06e5ad97134f1"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b8d44dd5a5a6e1e3f873750ebfa119e8956721d2"
 dependencies = [
  "anyhow",
  "nom 8.0.0",
@@ -552,7 +552,7 @@ dependencies = [
 [[package]]
 name = "lantern-emit"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#b019f839cc16890ef418ee8211c06e5ad97134f1"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b8d44dd5a5a6e1e3f873750ebfa119e8956721d2"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",
@@ -563,7 +563,7 @@ dependencies = [
 [[package]]
 name = "lantern-exprs"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#b019f839cc16890ef418ee8211c06e5ad97134f1"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b8d44dd5a5a6e1e3f873750ebfa119e8956721d2"
 dependencies = [
  "lantern-hir",
  "petgraph",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "lantern-hir"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#b019f839cc16890ef418ee8211c06e5ad97134f1"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b8d44dd5a5a6e1e3f873750ebfa119e8956721d2"
 dependencies = [
  "lantern-bytecode",
  "petgraph",
@@ -583,7 +583,7 @@ dependencies = [
 [[package]]
 name = "lantern-lift"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#b019f839cc16890ef418ee8211c06e5ad97134f1"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b8d44dd5a5a6e1e3f873750ebfa119e8956721d2"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",
@@ -594,7 +594,7 @@ dependencies = [
 [[package]]
 name = "lantern-structure"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#b019f839cc16890ef418ee8211c06e5ad97134f1"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b8d44dd5a5a6e1e3f873750ebfa119e8956721d2"
 dependencies = [
  "lantern-hir",
  "petgraph",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "lantern-vars"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#b019f839cc16890ef418ee8211c06e5ad97134f1"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#b8d44dd5a5a6e1e3f873750ebfa119e8956721d2"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 [[package]]
 name = "lantern"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#b1259d400c530b243428fc78c2d68e81c898120a"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#eef391999aaba9d206bef76dfe21fdca686a9977"
 dependencies = [
  "lantern-bytecode",
  "lantern-emit",
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "lantern-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#b1259d400c530b243428fc78c2d68e81c898120a"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#eef391999aaba9d206bef76dfe21fdca686a9977"
 dependencies = [
  "anyhow",
  "nom 8.0.0",
@@ -552,7 +552,7 @@ dependencies = [
 [[package]]
 name = "lantern-emit"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#b1259d400c530b243428fc78c2d68e81c898120a"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#eef391999aaba9d206bef76dfe21fdca686a9977"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",
@@ -563,7 +563,7 @@ dependencies = [
 [[package]]
 name = "lantern-exprs"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#b1259d400c530b243428fc78c2d68e81c898120a"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#eef391999aaba9d206bef76dfe21fdca686a9977"
 dependencies = [
  "lantern-hir",
  "petgraph",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "lantern-hir"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#b1259d400c530b243428fc78c2d68e81c898120a"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#eef391999aaba9d206bef76dfe21fdca686a9977"
 dependencies = [
  "lantern-bytecode",
  "petgraph",
@@ -583,7 +583,7 @@ dependencies = [
 [[package]]
 name = "lantern-lift"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#b1259d400c530b243428fc78c2d68e81c898120a"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#eef391999aaba9d206bef76dfe21fdca686a9977"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",
@@ -594,7 +594,7 @@ dependencies = [
 [[package]]
 name = "lantern-structure"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#b1259d400c530b243428fc78c2d68e81c898120a"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#eef391999aaba9d206bef76dfe21fdca686a9977"
 dependencies = [
  "lantern-hir",
  "petgraph",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "lantern-vars"
 version = "0.1.0"
-source = "git+https://github.com/Paint-a-Farm/lantern.git#b1259d400c530b243428fc78c2d68e81c898120a"
+source = "git+https://github.com/Paint-a-Farm/lantern.git#eef391999aaba9d206bef76dfe21fdca686a9977"
 dependencies = [
  "lantern-bytecode",
  "lantern-hir",

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A collection of command line tools used internally, cleaned up and refactored fo
 ## fs-luau-decompile
 
 ```
-Usage: fs-luau-decompile <input> [<output>] [-r] [-s] [-d] [-l] [--lantern] [--num-threads <num-threads>] [-c <indent-char>] [-i <indent-size>]
+Usage: fs-luau-decompile <input> [<output>] [-r] [-s] [-d] [--num-threads <num-threads>]
 
 Decode and decompile Luau .l64 bytecode files
 
@@ -17,16 +17,11 @@ Options:
   -r, --recursive   recursive mode if folder input
   -s, --silent      suppress output
   -d, --decode-only only decode files
-  -l, --function-line-info
-                    include line number info for functions when applicable
-  --lantern         use lantern decompiler instead of medal (requires --features lantern)
   --num-threads     set thread pool size when processing folders (0 = auto)
-  -c, --indent-char indentation character (space, tab)
-  -i, --indent-size indentation size for spaces
   --help, help      display usage information
 ```
 
-Decode and decompile Luau bytecode files (FS25). Embeds the [medal](https://github.com/scfmod/medal) decompiler by default.
+Decode and decompile Luau bytecode files (FS25). Uses the [Lantern](https://github.com/Paint-a-Farm/lantern) decompiler.
 
 Supports reading directly from GAR/DLC archives:
 ```sh
@@ -48,28 +43,8 @@ cargo run -p fs-luau-decompile -- <input> [<output>] [-r] [-s] [-d] [--num-threa
 cargo build --release -p fs-luau-decompile
 ```
 
-### Using Lantern
+NOTE: To update lantern to latest commit when updated:
 
-[Lantern](https://github.com/Paint-a-Farm/lantern) is an alternative decompiler with improved variable recovery and fewer output artifacts. It can be enabled as an optional feature:
-
-```sh
-# Build with lantern support
-cargo build --release -p fs-luau-decompile --features lantern
-
-# Use lantern instead of medal
-fs-luau-decompile --lantern scripts/main.l64
-
-# Batch decompile with lantern
-fs-luau-decompile --lantern -r dataS.gar/scripts/ ./output/
-```
-
-Without the `lantern` feature, the `--lantern` flag will print an error. The default behavior (medal) is unchanged.
-
-
-
-
-
-NOTE: To update lantern to latest commit when updated
 ```
 cargo update -p lantern
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 A collection of command line tools used internally, cleaned up and refactored for public release. Use at own risk.
 
-
+Requires [Rust/Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html) to build.
 
 ## fs-luau-decompile
 

--- a/fs-luau-decompile/Cargo.toml
+++ b/fs-luau-decompile/Cargo.toml
@@ -12,11 +12,5 @@ nom = "7.1.3"
 nom-leb128 = "0.2.0"
 regex = "1.11.1"
 rayon = "1.11.0"
-luau-lifter = { git = "https://github.com/scfmod/medal.git" }
-ast = { git = "https://github.com/scfmod/medal.git" }
-lantern = { git = "https://github.com/Paint-a-Farm/lantern.git", optional = true }
+lantern = { git = "https://github.com/Paint-a-Farm/lantern.git" }
 gar-lib = { git = "https://github.com/Paint-a-Farm/gar-lib.git" }
-
-[features]
-default = []
-lantern = ["dep:lantern"]

--- a/fs-luau-decompile/src/main.rs
+++ b/fs-luau-decompile/src/main.rs
@@ -1,6 +1,5 @@
 use anyhow::{Result, bail};
 use argh::FromArgs;
-use ast::formatter::IndentationMode;
 use fs_lib::{
     LUAU_DECODE_TABLES, buffer::BufferExtension, list_files_with_extension, path::PathExtension,
 };
@@ -9,28 +8,7 @@ use rayon::{
     ThreadPoolBuilder,
     iter::{IntoParallelIterator, ParallelIterator},
 };
-use std::{
-    path::{Path, PathBuf},
-    str::FromStr,
-};
-
-#[derive(Debug, PartialEq, Clone, Copy)]
-enum Indent {
-    Space,
-    Tab,
-}
-
-impl FromStr for Indent {
-    type Err = String;
-
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        match s {
-            "space" => Ok(Indent::Space),
-            "tab" => Ok(Indent::Tab),
-            _ => Err(format!("Unknown indent character enum: {}", s)),
-        }
-    }
-}
+use std::path::{Path, PathBuf};
 
 #[derive(FromArgs, PartialEq, Debug)]
 /// Decode and decompile Luau .l64 bytecode files
@@ -47,25 +25,9 @@ pub struct Cmd {
     #[argh(switch, short = 'd')]
     decode_only: bool,
 
-    /// include line number info for functions when applicable
-    #[argh(switch, short = 'l')]
-    function_line_info: bool,
-
     /// set thread pool size when processing folders (0 = auto)
     #[argh(option, default = "0")]
     num_threads: u8,
-
-    /// indentation character (space, tab)
-    #[argh(option, short = 'c', default = "Indent::Tab")]
-    indent_char: Indent,
-
-    /// indentation size for spaces
-    #[argh(option, short = 'i', default = "4")]
-    indent_size: u8,
-
-    /// use lantern decompiler instead of medal
-    #[argh(switch)]
-    lantern: bool,
 
     /// path to input file/folder
     #[argh(positional)]
@@ -102,12 +64,7 @@ fn decode_bytecode(buffer: &mut Vec<u8>, version: u8, is_dlc: bool) -> Result<()
     Ok(())
 }
 
-fn decompile_bytecode(
-    bytecode: &mut Vec<u8>,
-    write_function_line_info: bool,
-    indent_mode: &IndentationMode,
-    use_lantern: bool,
-) -> Result<Vec<u8>> {
+fn decompile_bytecode(bytecode: &mut Vec<u8>) -> Result<Vec<u8>> {
     let (version, is_encoded, is_dlc) = get_bytecode_info(&bytecode);
 
     if version == 0 {
@@ -118,36 +75,15 @@ fn decompile_bytecode(
         decode_bytecode(bytecode, version, is_dlc)?;
     }
 
-    if use_lantern {
-        #[cfg(feature = "lantern")]
-        {
-            return Ok(lantern::decompile_bytecode(&bytecode, 1)
-                .as_bytes()
-                .to_vec());
-        }
-        #[cfg(not(feature = "lantern"))]
-        bail!("--lantern requires building with --features lantern");
-    }
-
-    Ok(luau_lifter::decompile_bytecode_with_opts(
-        &bytecode,
-        1,
-        write_function_line_info,
-        *indent_mode,
-    )
-    .as_bytes()
-    .to_vec())
+    Ok(lantern::decompile_bytecode(&bytecode, 1)
+        .as_bytes()
+        .to_vec())
 }
 
-fn decompile_file<P: AsRef<Path>>(
-    file: P,
-    write_function_line_info: bool,
-    indent_mode: &IndentationMode,
-    use_lantern: bool,
-) -> Result<Vec<u8>> {
+fn decompile_file<P: AsRef<Path>>(file: P) -> Result<Vec<u8>> {
     let mut bytecode = Vec::read_from_file(&file)?;
 
-    match decompile_bytecode(&mut bytecode, write_function_line_info, indent_mode, use_lantern) {
+    match decompile_bytecode(&mut bytecode) {
         Ok(result) => Ok(result),
         Err(e) => bail!("{}: {}", file.as_ref().display(), e),
     }
@@ -169,18 +105,12 @@ fn decode_file<P: AsRef<Path>>(file: P) -> Result<Vec<u8>> {
     Ok(bytecode)
 }
 
-fn decompile_from_archive(
-    archive: &GarArchive,
-    path: &str,
-    write_function_line_info: bool,
-    indent_mode: &IndentationMode,
-    use_lantern: bool,
-) -> Result<Vec<u8>> {
+fn decompile_from_archive(archive: &GarArchive, path: &str) -> Result<Vec<u8>> {
     let mut bytecode = archive
         .read_file(path)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
 
-    match decompile_bytecode(&mut bytecode, write_function_line_info, indent_mode, use_lantern) {
+    match decompile_bytecode(&mut bytecode) {
         Ok(result) => Ok(result),
         Err(e) => bail!("{}: {}", path, e),
     }
@@ -204,21 +134,8 @@ fn decode_from_archive(archive: &GarArchive, path: &str) -> Result<Vec<u8>> {
     Ok(bytecode)
 }
 
-fn list_l64_files<'a>(archive: &'a GarArchive, base: &str, recursive: bool) -> Vec<&'a str> {
-    archive
-        .files_with_extension(base, "l64", recursive)
-        .into_iter()
-        .filter(|f| !f.contains("XMLSchema.l64"))
-        .collect()
-}
-
 fn main() -> Result<()> {
     let cli: Cmd = argh::from_env();
-
-    let indent_mode: IndentationMode = match cli.indent_char {
-        Indent::Space => IndentationMode::Spaces(cli.indent_size),
-        Indent::Tab => IndentationMode::Tab,
-    };
 
     match GarPath::parse(&cli.input) {
         GarPath::Filesystem(path) => {
@@ -232,7 +149,7 @@ fn main() -> Result<()> {
                             output_file.set_extension("lua");
                         }
 
-                        decompile_file(&path, cli.function_line_info, &indent_mode, cli.lantern)?
+                        decompile_file(&path)?
                     }
                     true => decode_file(&path)?,
                 };
@@ -259,13 +176,7 @@ fn main() -> Result<()> {
                     .build_global()
                     .unwrap();
 
-                let files: Vec<_> = list_files_with_extension(&path, r"l64", cli.recursive)?
-                    .into_iter()
-                    .filter(|f| {
-                        let name = f.file_name().and_then(|n| n.to_str()).unwrap_or("");
-                        !name.contains("XMLSchema")
-                    })
-                    .collect();
+                let files: Vec<_> = list_files_with_extension(&path, r"l64", cli.recursive)?;
 
                 let iter_result = files.into_par_iter().try_for_each(|file| -> Result<()> {
                     let mut output_file: PathBuf = file
@@ -279,7 +190,7 @@ fn main() -> Result<()> {
                                 output_file.set_extension("lua");
                             }
 
-                            decompile_file(&file, cli.function_line_info, &indent_mode, cli.lantern)?
+                            decompile_file(&file)?
                         }
                         true => decode_file(&file)?,
                     };
@@ -319,7 +230,7 @@ fn main() -> Result<()> {
                 let result = if cli.decode_only {
                     decode_from_archive(&archive, base)?
                 } else {
-                    decompile_from_archive(&archive, base, cli.function_line_info, &indent_mode, cli.lantern)?
+                    decompile_from_archive(&archive, base)?
                 };
 
                 let filename = Path::new(base).file_name().unwrap();
@@ -335,7 +246,10 @@ fn main() -> Result<()> {
                 }
             } else {
                 // Directory - process multiple files
-                let files = list_l64_files(&archive, base, cli.recursive);
+                let files: Vec<&str> = archive
+                    .files_with_extension(base, "l64", cli.recursive)
+                    .into_iter()
+                    .collect();
 
                 if files.is_empty() {
                     bail!("No .l64 files found in archive path: {}", base);
@@ -345,13 +259,7 @@ fn main() -> Result<()> {
                     let result = if cli.decode_only {
                         decode_from_archive(&archive, file)?
                     } else {
-                        decompile_from_archive(
-                            &archive,
-                            file,
-                            cli.function_line_info,
-                            &indent_mode,
-                            cli.lantern,
-                        )?
+                        decompile_from_archive(&archive, file)?
                     };
 
                     let rel_path = file


### PR DESCRIPTION
## Summary
- Remove medal (luau-lifter/ast) dependencies entirely
- Make lantern the default and only decompiler (no longer optional)
- Remove medal-specific CLI options: `--lantern`, `--indent-char`, `--indent-size`, `--function-line-info`
- Remove `XMLSchema.l64` skip filter
- Update README to reflect simplified CLI

## Test plan
- [ ] `cargo build -p fs-luau-decompile` compiles cleanly
- [ ] Single file decompilation works: `fs-luau-decompile dataS.gar/scripts/main.l64`
- [ ] Batch decompilation works: `fs-luau-decompile -r dataS.gar/scripts/ ./output/`
- [ ] Decode-only mode still works: `fs-luau-decompile -d input.l64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)