### PR TITLE
Fix encoding detection for FS22 LuaJIT files

### DIFF
--- a/fs-luajit-decompile/src/main.rs
+++ b/fs-luajit-decompile/src/main.rs
@@ -38,7 +38,8 @@ fn is_valid(buffer: &Vec<u8>) -> bool {
 }
 
 fn is_encoded(buffer: &Vec<u8>) -> bool {
-    buffer[4] == 0xFC
+    // Check if version byte (buffer[3]) has a decode table
+    LUAJIT_DECODE_TABLES.contains_key(&buffer[3])
 }
 
 fn decode(buffer: &mut Vec<u8>) -> Result<()> {


### PR DESCRIPTION
## Problem
`is_encoded()` checked if `buffer[4] == 0xFC` to detect encoded files, but FS22 .l64 files have different values at byte 4 (e.g. `0xFB`), causing the decode step to be skipped entirely.

This resulted in raw encoded bytecode being passed to `luajit-decompiler.exe`, which crashed with `STATUS_STACK_BUFFER_OVERRUN` (exit code -1073740791).

## Solution
Check if `buffer[3]` (version byte) exists in `LUAJIT_DECODE_TABLES` instead of hardcoding a byte 4 check. The decode tables already correctly support versions 3 and 4.

## Change
```rust
// Before (incorrect)
fn is_encoded(buffer: &Vec<u8>) -> bool {
    buffer[4] == 0xFC
}

// After (correct)  
fn is_encoded(buffer: &Vec<u8>) -> bool {
    LUAJIT_DECODE_TABLES.contains_key(&buffer[3])
}
```

Fixes #13